### PR TITLE
fix: uri parsing (closes #2)

### DIFF
--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -45,7 +45,7 @@ local function get_url_data(mode)
   if not remote then return nil end
 
   local repo = git.get_repo(remote)
-  if not repo then return nil end
+  if not repo or vim.tbl_isempty(repo) then return nil end
 
   local buf_repo_path = buffer.get_relative_path(git.get_git_root())
 


### PR DESCRIPTION
Closes https://github.com/ruifm/gitlinker.nvim/issues/2

Handle uris that do not end in ".git" and more cleanly strip out the
protocol from the uri.

@tjdevries does this fix your issue and does the fix look alright to you?