### PR TITLE
Fix/Host contains hyphens

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ callbacks = {
 }
 ```
 
+**Warning**: The keys in `callbacks` table are actually interpreted as lua
+regexes. If your url contains magic lua character such as `-`, it needs to be
+escaped as `%-`.
+
 ### Options
 
 - `remote`

--- a/doc/gitlinker.txt
+++ b/doc/gitlinker.txt
@@ -212,6 +212,9 @@ from my LAN) and but the web interface is public:
       end
   }
 <
+Warning: The keys in `callbacks` table are actually interpreted as lua
+regexes. If your url contains magic lua character such as `-`, it needs to be
+escaped as `%-`.
 
 
 opts                                                           *gitlinker-opts*

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -82,12 +82,12 @@ local function is_rev_in_remote(revspec, remote)
   return is_in_remote
 end
 
-local chars = "[_%-%w%.]+"
+local allowed_chars = "[_%-%w%.]+"
 
 -- strips the protocol (https://, git@, ssh://, etc)
 local function strip_protocol(uri, errs)
-  local protocol_schema = chars .. "://"
-  local ssh_schema = chars .. "@"
+  local protocol_schema = allowed_chars .. "://"
+  local ssh_schema = allowed_chars .. "@"
 
   local stripped_uri = uri:match(protocol_schema .. "(.+)$")
     or uri:match(ssh_schema .. "(.+)$")
@@ -114,7 +114,7 @@ local function strip_uri(uri, errs)
 end
 
 local function parse_host(stripped_uri, errs)
-  local host_capture = "(" .. chars .. ")[:/].+$"
+  local host_capture = "(" .. allowed_chars .. ")[:/].+$"
   local host = stripped_uri:match(host_capture)
   if not host then
     table.insert(
@@ -127,7 +127,7 @@ end
 
 local function parse_port(stripped_uri, host)
   assert(host)
-  local port_capture = host .. ":([0-9]+)[:/].+$"
+  local port_capture = allowed_chars .. ":([0-9]+)[:/].+$"
   return stripped_uri:match(port_capture)
 end
 
@@ -144,7 +144,7 @@ local function parse_repo_path(stripped_uri, host, port, errs)
   end
 
   -- add parsed host to path capture
-  path_capture = host .. path_capture
+  path_capture = allowed_chars .. path_capture
 
   -- parse repo path
   local repo_path = stripped_uri:match(path_capture)

--- a/lua/gitlinker/hosts.lua
+++ b/lua/gitlinker/hosts.lua
@@ -171,7 +171,7 @@ end
 function M.get_matching_callback(target_host)
   local matching_callback
   for host, callback in pairs(M.callbacks) do
-    if host:match(target_host) then
+    if target_host:match(host) then
       matching_callback = callback
       break
     end


### PR DESCRIPTION
# Background

As described in #27 

# Solution

Escape hyphens in `host` using `string:gsub()`

# Out of scope changes

This PR contains an out of scope changes in `hosts.lua`:

```diff
for host, callback in pairs(M.callbacks) do
-   if host:match(target_host) then
+   if target_host:match(host) then
      matching_callback = callback
      break
```

which reversed the sides of `host` and `target_host` matching. This is because:

- The former matching requires escaping `target_host`, or the `:match()` function will return `nil`
- The later matching gives a slightly more flexibility in writing custom `callbacks` option: you don't need to provide the full host name, just passing part of it is enough.