### PR TITLE
fix(buffer.get_range)!: visual mode gets current

### DIFF
--- a/lua/gitlinker/buffer.lua
+++ b/lua/gitlinker/buffer.lua
@@ -15,8 +15,8 @@ function M.get_range(mode, add_current_line_on_normal_mode)
   local lstart
   local lend
   if mode == "v" then
-    lstart = api.nvim_buf_get_mark(0, "<")[1]
-    lend = api.nvim_buf_get_mark(0, ">")[1]
+    lstart = vim.fn.getpos("v")[2]
+    lend = vim.fn.getcurpos()[2]
   elseif add_current_line_on_normal_mode == true then
     lstart = M.get_curr_line()
   end


### PR DESCRIPTION
It turns out, `nvim_buf_get_mark(0, "<")[1]`, isn't quite the right
thing. The "<" and ">" marks get they _last_ selected visual area. When
you currently have a visual selection, it's ignored.

I found [kommentary][1] used `vim.fn.getpos` and `getcurpos` for similar
functionality, so I'm using that instead.

[1]: https://github.com/b3nj5m1n/kommentary/blob/09d332c66b7155b14eb22c9129aee44d9d2ff496/lua/kommentary/init.lua#L85-L90