### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ looking for is `require"gitlinker".get_buf_range_url(mode, user_opts)` where:
 
   ``` lua
   vim.api.nvim_set_keymap('n', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("n", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
-  vim.api.nvim_set_keymap('v', '<leader>gb', ':lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>')
+  vim.api.nvim_set_keymap('v', '<leader>gb', ':lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {})
   ```
 
 ### Repo home page url


### PR DESCRIPTION
There's a typo in the README where nvim_set_keymap only received 3 arguments. (https://neovim.io/doc/user/api.html#nvim_set_keymap())