### PR TITLE
fix: use '<cmd>' instead of ':' for default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ looking for is `require"gitlinker".get_buf_range_url(mode, user_opts)` where:
 
   ``` lua
   vim.api.nvim_set_keymap('n', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("n", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
-  vim.api.nvim_set_keymap('v', '<leader>gb', ':lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {})
+  vim.api.nvim_set_keymap('v', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {})
   ```
 
 ### Repo home page url

--- a/doc/gitlinker.txt
+++ b/doc/gitlinker.txt
@@ -88,7 +88,7 @@ looking for is `require"gitlinker".get_buf_range_url(mode, user_opts)` where:
 
 >
   vim.api.nvim_set_keymap('n', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("n", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
-  vim.api.nvim_set_keymap('v', '<leader>gb', ':lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>'))
+  vim.api.nvim_set_keymap('v', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>'))
 <
 
 ==============================================================================

--- a/lua/gitlinker/mappings.lua
+++ b/lua/gitlinker/mappings.lua
@@ -11,7 +11,7 @@ local function set_keymap(mode, keys, mapping_opts)
   api.nvim_set_keymap(
     mode,
     keys,
-    ":lua require'gitlinker'.get_buf_range_url('" .. mode .. "')<cr>",
+    "<cmd>lua require'gitlinker'.get_buf_range_url('" .. mode .. "')<cr>",
     mapping_opts
   )
 end


### PR DESCRIPTION
Hey there, the default mappings don't seem to be working quite right when I select multiple lines in visual mode. They always seem to return a single line range like `#L5-L5`. (I'm on neovim 0.5.1)

Switching out the `:` for `<cmd>` fixes the issue for me so that's what I did here. To be honest, I'm not sure why it works, I just saw it in other mappings and gave it a shot 🤷 .