### PR TITLE
chore: use new log level names

### DIFF
--- a/doc/gitlinker.txt
+++ b/doc/gitlinker.txt
@@ -88,7 +88,7 @@ looking for is `require"gitlinker".get_buf_range_url(mode, user_opts)` where:
 
 >
   vim.api.nvim_set_keymap('n', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("n", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
-  vim.api.nvim_set_keymap('v', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>'))
+  vim.api.nvim_set_keymap('v', '<leader>gb', '<cmd>lua require"gitlinker".get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
 <
 
 ==============================================================================

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -60,7 +60,7 @@ end
 local function get_buf_range_url_data(mode, user_opts)
   local git_root = git.get_git_root()
   if not git_root then
-    vim.notify("Not in a git repository", vim.log.levels.Error)
+    vim.notify("Not in a git repository", vim.log.levels.ERROR)
     return nil
   end
   mode = mode or "n"
@@ -79,7 +79,7 @@ local function get_buf_range_url_data(mode, user_opts)
   if not git.is_file_in_rev(buf_repo_path, rev) then
     vim.notify(
       string.format("'%s' does not exist in remote '%s'", buf_repo_path, remote),
-      vim.log.levels.Error
+      vim.log.levels.ERROR
     )
     return nil
   end
@@ -95,7 +95,7 @@ local function get_buf_range_url_data(mode, user_opts)
         "No line numbers were computed because '%s' has changes",
         buf_path
       ),
-      vim.log.levels.Warning
+      vim.log.levels.WARN
     )
   end
 

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -199,7 +199,7 @@ function M.get_closest_remote_compatible_rev(remote)
       "Failed to get closest revision in that exists in remote '%s'",
       remote
     ),
-    vim.log.levels.Error
+    vim.log.levels.ERROR
   )
   return nil
 end
@@ -219,7 +219,7 @@ function M.get_repo_data(remote)
 
   local repo = parse_uri(remote_uri, errs)
   if not repo or vim.tbl_isempty(repo) then
-    vim.notify(table.concat(errs), vim.log.levels.Error)
+    vim.notify(table.concat(errs), vim.log.levels.ERROR)
   end
   return repo
 end
@@ -231,7 +231,7 @@ end
 function M.get_branch_remote()
   local remotes = get_remotes()
   if #remotes == 0 then
-    vim.notify("Git repo has no remote", vim.log.levels.Error)
+    vim.notify("Git repo has no remote", vim.log.levels.ERROR)
     return nil
   end
   if #remotes == 1 then
@@ -249,7 +249,7 @@ function M.get_branch_remote()
       Otherwise, choose one of them using
       require'gitlinker'.setup({opts={remote='<remotename>'}}).
     ]],
-      vim.log.levels.Warning
+      vim.log.levels.WARN
     )
     return nil
   end

--- a/lua/gitlinker/hosts.lua
+++ b/lua/gitlinker/hosts.lua
@@ -179,7 +179,7 @@ function M.get_matching_callback(target_host)
   if not matching_callback then
     vim.notify(
       string.format("No host callback defined for host '%s'", target_host),
-      vim.log.levels.Error
+      vim.log.levels.ERROR
     )
   end
   return matching_callback


### PR DESCRIPTION
Hi! Thanks for this great plugin :). I can't recall neovim ever changing the capitalization of these "enum" values, but [they should be capitalized](https://github.com/neovim/neovim/blob/abdf3a8128b78fb98ee944bc5d3086c680d779ed/src/nvim/lua/vim.lua#L119-L127). The existing log levels all produce `nil` (e.g., `vim.log.levels.Error == nil`), which basically makes neovim interpret them as the default log level (INFO)