### PR TITLE
Parse remote host from ssh config

### DIFF
--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local job = require("plenary.job")
 local path = require("plenary.path")
+local ssh = require("gitlinker.ssh")
 
 -- wrap the git command to do the right thing always
 local function git(args, cwd)
@@ -69,6 +70,8 @@ local function strip_protocol(uri, errs)
 
   local stripped_uri = uri:match(protocol_schema .. "(.+)$")
     or uri:match(ssh_schema .. "(.+)$")
+    or ssh.fix_hostname(uri)
+
   if not stripped_uri then
     table.insert(
       errs,

--- a/lua/gitlinker/ssh.lua
+++ b/lua/gitlinker/ssh.lua
@@ -1,0 +1,55 @@
+local M = {}
+
+local job = require("plenary.job")
+
+-- wrap the ssh command to do the right thing always
+local function ssh(args)
+  local output
+  local p = job:new({
+    command = "ssh",
+    args = args,
+  })
+  p:after_success(function(j)
+    output = j:result()
+  end)
+  p:sync()
+  return output or {}
+end
+
+local function as_table(data)
+  local result = {}
+  for _, line in ipairs(data) do
+    for key, value in string.gmatch(line, "(%w+)%s+(.*)") do
+      result[key] = value
+    end
+  end
+  return result
+end
+
+local function get_configuration(alias)
+  local configuration = ssh({ "-G", alias })
+  return as_table(configuration)
+end
+
+local function get_hostname(alias)
+  return get_configuration(alias)["hostname"]
+end
+
+--- Fixes aliased remote uri using the hostname set in ssh config.
+-- In some cases, the user can create an alias for a given user/hostname.
+-- So this function replaces the aliased name with the hostname set in ssh
+-- config.
+-- @params uri Remote uri from which alias will be replaced
+-- @return uri with replaced alias or nil
+function M.fix_hostname(uri)
+  local alias = string.match(uri, "([^:]+):.*")
+  local hostname = get_hostname(alias)
+
+  if alias == hostname then
+    return nil
+  end
+
+  return string.gsub(uri, alias, hostname)
+end
+
+return M


### PR DESCRIPTION
In some situations, a user can set a `Host` rule in [ssh config][0], which defines an alias for a hostname. Such as:

```
Host example
    Hostname example.com
    User git
    IdentityFile ~/.ssh/gitea
```

The remote uri will look like: `example:username/repository.git`.

To avoid problems parsing the remote uri, an `ssh` module was created to set the proper hostname based on ssh config.

Closes #53 

[0]: https://www.man7.org/linux/man-pages/man5/ssh_config.5.html