### PR TITLE
add description to key mappings

### DIFF
--- a/lua/gitlinker/mappings.lua
+++ b/lua/gitlinker/mappings.lua
@@ -8,6 +8,9 @@ local function set_keymap(mode, keys, mapping_opts)
     { noremap = true, silent = true },
     mapping_opts or {}
   )
+  if vim.fn.has('nvim-0.7.0') == 1 then
+    mapping_opts.desc = "Generate shareable permalink"
+  end
   api.nvim_set_keymap(
     mode,
     keys,


### PR DESCRIPTION
I use [which-key](https://github.com/folke/which-key.nvim) to help me remember key mappings. Currently the gitlinker entry looks like this:

> `y ➜ require'gitlinker'.get_buf_range_url('v')`

With this patch, it looks like this:

> `y ➜ Generate shareable permalink`

`desc` is available [since neovim 0.7.0](https://github.com/neovim/neovim/commit/b218d02c442ebacba1fdef0cca9e40315a46aedd).