### PR TITLE
bug fix: use explorer command to open browser in windows

### DIFF
--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -15,8 +15,15 @@ end
 -- Uses xdg-open
 -- @param url the url string
 function M.open_in_browser(url)
-  local command = vim.loop.os_uname().sysname == "Darwin" and "open"
-    or "xdg-open"
+  local command = "xdg-open"
+  local sysname = vim.loop.os_uname().sysname
+  if sysname == "Darwin" then
+    command = "open"
+  elseif
+      string.len(sysname) >= 7 and string.sub(sysname, 1, 7) == "windows"
+  then
+    command = "explorer"
+  end
   job:new({ command = command, args = { url } }):start()
 end
 

--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -1,31 +1,31 @@
 local M = {}
 
-local api = vim.api
-local job = require("plenary.job")
+local pjob = require("plenary.job")
+local os = vim.loop.os_uname().sysname
 
---- copies the url to clipboard
+-- Copy url to clipboard
 --
 -- @param url the url string
 function M.copy_to_clipboard(url)
-  api.nvim_command("let @+ = '" .. url .. "'")
+  vim.api.nvim_command("let @+ = '" .. url .. "'")
 end
 
---- opens the url in your default browser
+-- Open url in browser
 --
--- Uses xdg-open
+-- Use urlview.nvim's system implementation.
+-- Please check: https://github.com/axieax/urlview.nvim/blob/main/lua/urlview/actions.lua#L38
+--
 -- @param url the url string
 function M.open_in_browser(url)
-  local command = "xdg-open"
-  local sysname = vim.loop.os_uname().sysname
-  if sysname == "Darwin" then
-    command = "open"
-  elseif
-    string.len(sysname) >= 7
-    and string.sub(string.lower(sysname), 1, 7) == "windows"
-  then
-    command = "explorer"
+  local j
+  if os == "Darwin" then
+    j = pjob:new({ command = "open", args = { url } })
+  elseif os:match("Windows") then
+    j = pjob:new({ command = "cmd", args = { "/C", "start", url } })
+  else
+    j = pjob:new({ command = "xdg-open", args = { url } })
   end
-  job:new({ command = command, args = { url } }):start()
+  j:start()
 end
 
 return M

--- a/lua/gitlinker/actions.lua
+++ b/lua/gitlinker/actions.lua
@@ -20,7 +20,8 @@ function M.open_in_browser(url)
   if sysname == "Darwin" then
     command = "open"
   elseif
-      string.len(sysname) >= 7 and string.sub(sysname, 1, 7) == "windows"
+    string.len(sysname) >= 7
+    and string.sub(string.lower(sysname), 1, 7) == "windows"
   then
     command = "explorer"
   end

--- a/lua/gitlinker/mappings.lua
+++ b/lua/gitlinker/mappings.lua
@@ -17,9 +17,13 @@ local function set_keymap(mode, keys, mapping_opts)
 end
 
 function M.set(mappings)
-  mappings = mappings or "<leader>gy"
-  set_keymap("n", mappings)
-  set_keymap("v", mappings, { silent = false })
+  if mappings == nil then
+    mappings = "<leader>gy"
+  end
+  if mappings and string.len(mappings) > 0 then
+    set_keymap("n", mappings)
+    set_keymap("v", mappings, { silent = false })
+  end
 end
 
 return M


### PR DESCRIPTION
As mentioned in #75 , open link in windows is not supported for now.
I add detection for windows, and use `explorer` command to open url.
Please see: https://stackoverflow.com/a/23039509/4438921

Manually tested:
![image](https://user-images.githubusercontent.com/6496887/219867967-5255682b-1b7e-4517-8d3d-8df4a5c4155c.png)

![image](https://user-images.githubusercontent.com/6496887/219868216-98662810-b559-47eb-9ea4-ea924de7626b.png)


As showed in picture, the browser is opened correctly. But the url is actually wrong.
In Windows, the path separator is `\` instead of `/`.

Any way this command should be good.