### PR TITLE
only add end line number to url if different than start line number

### DIFF
--- a/lua/gitlinker/hosts.lua
+++ b/lua/gitlinker/hosts.lua
@@ -20,7 +20,7 @@ function M.get_github_type_url(url_data)
     return url
   end
   url = url .. "#L" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. "-L" .. url_data.lend
   end
   return url
@@ -38,7 +38,7 @@ function M.get_gitea_type_url(url_data)
     return url
   end
   url = url .. "#L" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. "-L" .. url_data.lend
   end
   return url
@@ -56,7 +56,7 @@ function M.get_gitlab_type_url(url_data)
     return url
   end
   url = url .. "#L" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. "-" .. url_data.lend
   end
   return url
@@ -74,7 +74,7 @@ function M.get_bitbucket_type_url(url_data)
     return url
   end
   url = url .. "#lines-" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. ":" .. url_data.lend
   end
 
@@ -93,7 +93,7 @@ function M.get_gogs_type_url(url_data)
     return url
   end
   url = url .. "#L" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. "-L" .. url_data.lend
   end
 
@@ -129,7 +129,7 @@ function M.get_srht_type_url(url_data)
     return url
   end
   url = url .. "#L" .. url_data.lstart
-  if url_data.lend then
+  if url_data.lend and url_data.lend ~= url_data.lstart then
     url = url .. "-" .. url_data.lend
   end
 


### PR DESCRIPTION
I use `add_current_line_on_normal_mode = false`. When I want to generate a link to a specific line I use visual mode, but noticed that the URLs link to a one-line range (`github.com/org/repo/file#L3-L3`) instead of linking to the line (`github.com/org/repo/file#L3`). This change makes it so that the ending line number is only appended to the URL if it's different than the starting line number.