### PR TITLE
Added support for bare repositories (fixes #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ require"gitlinker".setup({
     action_callback = require"gitlinker.actions".copy_to_clipboard,
     -- print the url after performing the action
     print_url = true,
+    -- list of bare repositories to check
+    bare_repos = {}, -- { { git_dir_1, git_work_tree_1 }, ... },
   },
   callbacks = {
         ["github.com"] = require"gitlinker.hosts".get_github_type_url,

--- a/doc/gitlinker.txt
+++ b/doc/gitlinker.txt
@@ -35,18 +35,29 @@ installed.
 
 * packer.nvim
 
->
+>lua
   use {
       'ruifm/gitlinker.nvim',
       requires = 'nvim-lua/plenary.nvim',
   }
 <
 
+* lazy.nvim
+
+>lua
+  return {
+    'ruifm/gitlinker.nvim',
+    dependencies = 'nvim-lua/plenary.nvim',
+    keys = "<leader>gy",
+    opts = true
+  }
+<
+
 * vim-plug
 
->
-Plug 'nvim-lua/plenary.nvim'
-Plug 'ruifm/gitlinker.nvim'
+>vim
+  Plug 'nvim-lua/plenary.nvim'
+  Plug 'ruifm/gitlinker.nvim'
 <
 
 ==============================================================================
@@ -126,6 +137,8 @@ Here’s all the options with their defaults:
       print_url = true,
       -- mapping to call url generation
       mappings = "<leader>gy"
+      -- list of bare repositories to check { { git_dir_1, git_work_tree_1 }, ... }
+      bare_repos = {}
     },
     callbacks = {
           ["github.com"] = require"gitlinker.hosts".get_github_type_url,
@@ -259,6 +272,23 @@ ojroques/vim-oscyank and use its `OSCYankString` function:
   }
 <
 For the above setup, make sure that ojroques/vim-oscyank is also installed.
+
+bare_repos                                       *gitlinker-bare-repositories*
+
+A list of bare repositories to check when a the current buffer doesn't seem
+inside a git repo.
+By default is empty, you can insert your repositories' git_dir and
+git_work_tree, for example if you track your dotfiles with a bare repo:
+>lua
+  require'gitlinker'.setup{
+    opts = {
+      bare_repos = {
+     -- { GIT_DIR,     GIT_WORK_TREE }
+        { "$HOME/.dotfiles", "$HOME" },
+      }
+    },
+  }
+<
 
 remote                                                     *gitlinker-mappings*
 

--- a/lua/gitlinker.lua
+++ b/lua/gitlinker.lua
@@ -16,6 +16,7 @@ M.actions = require("gitlinker.actions")
 -- Sets the mappings
 --
 -- @param config table with the schema
+-- ```lua
 -- {
 --   opts = {
 --    remote = "<remotename>", -- force the use of a specific remote
@@ -28,15 +29,13 @@ M.actions = require("gitlinker.actions")
 --   },
 --  mappings = "<keys>"-- keys for normal and visual mode keymaps
 -- }
+-- ```
 -- @param user_opts a table to override options passed in M.setup()
 function M.setup(config)
   if config then
     opts.setup(config.opts)
-    M.hosts.callbacks = vim.tbl_deep_extend(
-      "force",
-      M.hosts.callbacks,
-      config.callbacks or {}
-    )
+    M.hosts.callbacks =
+      vim.tbl_deep_extend("force", M.hosts.callbacks, config.callbacks or {})
     mappings.set(config.mappings)
   else
     opts.setup()
@@ -84,10 +83,8 @@ local function get_buf_range_url_data(mode, user_opts)
       vim.log.levels.WARN
     )
   end
-  local range = buffer.get_range(
-    mode,
-    user_opts.add_current_line_on_normal_mode
-  )
+  local range =
+    buffer.get_range(mode, user_opts.add_current_line_on_normal_mode)
 
   return vim.tbl_extend("force", repo_url_data, {
     rev = rev,
@@ -137,9 +134,8 @@ end
 function M.get_repo_url(user_opts)
   user_opts = vim.tbl_deep_extend("force", opts.get(), user_opts or {})
 
-  local repo_url_data = git.get_repo_data(
-    git.get_branch_remote() or user_opts.remote
-  )
+  local repo_url_data =
+    git.get_repo_data(git.get_branch_remote() or user_opts.remote)
   if not repo_url_data then
     return nil
   end

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -248,9 +248,8 @@ function M.get_branch_remote()
     return nil
   end
 
-  local remote_from_upstream_branch = upstream_branch:match(
-    "^(" .. allowed_chars .. ")%/"
-  )
+  local remote_from_upstream_branch =
+    upstream_branch:match("^(" .. allowed_chars .. ")%/")
   if not remote_from_upstream_branch then
     error(
       string.format(

--- a/lua/gitlinker/opts.lua
+++ b/lua/gitlinker/opts.lua
@@ -5,6 +5,7 @@ local defaults = {
   add_current_line_on_normal_mode = true, -- if true adds the line nr in the url for normal mode
   action_callback = require("gitlinker.actions").copy_to_clipboard, -- callback for what to do with the url
   print_url = true, -- print the url after action
+  bare_repos = {}, -- list of bare repositories to check { { git_dir_1, git_work_tree_1 }, ... }
 }
 
 local opts


### PR DESCRIPTION
## Usage:
By adding bare repository directories and their corresponding work_tree paths to `config.bare_repos`, users can now utilize the plugin with files tracked by those repositories. Multiple worktrees are not currently supported but can be implemented easily in the future.

## Changes Made:
Added a new option to the configuration, `bare_repos`, which is a list of pairs `{git_dir, git_work_tree}`.
If the plugin is used in a buffer associated with a bare repository, the first git command (git rev-parse) would fail, as the buffer is not in a regular git repo. To handle this, subsequent similar git commands are made with the `--git-dir` and `--work-tree` flags.
When a buffer is identified as belonging to one of the bare repositories specified in `config.bare_repos`, the information is cached for subsequent calls within the same session.

## Example:
A common use case is having a bare repository for managing dotfiles, that would be treated like so assuming the repo is in the `.dotfiles` folder and `$HOME` is the worktree:
```lua
config.bare_repos = {
    { "$HOME/.dotfiles", "$HOME" }
}
```