### PR TITLE
doc: fix instructions for OSCYank integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ You can define your own action callback.
 
 For example, to copy the url over a remote SSH session with an
 [OSC52][osc52]-compatible terminal, you can integrate gitlinker with
-[ojroques/vim-oscyank][oscyank] and use its `OSCYankString` function:
+[ojroques/vim-oscyank][oscyank] and use its `OSCYank` function:
 
 ```lua
 require'gitlinker'.setup{
@@ -254,7 +254,7 @@ require'gitlinker'.setup{
       -- yank to unnamed register
       vim.api.nvim_command('let @" = \'' .. url .. '\'')
       -- copy to the system clipboard using OSC52
-      vim.fn.OSCYankString(url)
+      vim.fn.OSCYank(url)
     end,
   },
 }


### PR DESCRIPTION
The instructions in the README need to be fixed now that the `OSCYankString` function has been renamed to [`OSCYank`](https://github.com/ojroques/vim-oscyank/blob/7250d51bda669ce1d7f334f2f5e6be012daddcde/plugin/oscyank.vim#L128)