### PR TITLE
configurable git command timeout

### DIFF
--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -16,7 +16,7 @@ local function git(args, cwd)
   p:after_success(function(j)
     output = j:result()
   end)
-  p:sync(M.timeout)
+  p:sync(M.git_timeout)
   return output or {}
 end
 

--- a/lua/gitlinker/git.lua
+++ b/lua/gitlinker/git.lua
@@ -3,6 +3,8 @@ local M = {}
 local job = require("plenary.job")
 local path = require("plenary.path")
 
+M.git_timeout = 5000
+
 -- wrap the git command to do the right thing always
 local function git(args, cwd)
   local output
@@ -14,7 +16,7 @@ local function git(args, cwd)
   p:after_success(function(j)
     output = j:result()
   end)
-  p:sync()
+  p:sync(M.timeout)
   return output or {}
 end
 

--- a/lua/gitlinker/opts.lua
+++ b/lua/gitlinker/opts.lua
@@ -1,10 +1,13 @@
 local M = {}
 
+local git = require("gitlinker.git")
+
 local defaults = {
   remote = "origin", -- force the use of a specific remote
   add_current_line_on_normal_mode = true, -- if true adds the line nr in the url for normal mode
   action_callback = require("gitlinker.actions").copy_to_clipboard, -- callback for what to do with the url
   print_url = true, -- print the url after action
+  git_timeout = 5000, -- by default, any git command after 5 seconds.
 }
 
 local opts
@@ -14,6 +17,9 @@ function M.setup(user_opts)
     opts = vim.tbl_deep_extend("force", {}, defaults)
   end
   opts = vim.tbl_deep_extend("force", opts, user_opts or {})
+  if opts.git_timeout then
+    git.git_timeout = opts.git_timeout
+  end
 end
 
 function M.get()


### PR DESCRIPTION
This is a naive change to allow increasing the timeout from the plenary default of 5000ms. When working with a large repo, sometimes a git command might take more than 5 seconds, in which case we get an annoying error in neovim and whatever we tried to do fails. Using `require("gitlinker").setup({opts={git_timeout=50000}})` we can increase to whatever timeout we desire to solve this little problem.