### PR TITLE
feat: add git.woa.com host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ co-workers.
 
 - [github](https://github.com)
 - [gitlab](https://gitlab.com)
+- [git.woa](https://git.woa.com)
 - [gitea](https://try.gitea.io)
 - [bitbucket](https://bitbucket.org)
 - [gogs](https://gogs.io)
@@ -130,6 +131,7 @@ require"gitlinker".setup({
   callbacks = {
         ["github.com"] = require"gitlinker.hosts".get_github_type_url,
         ["gitlab.com"] = require"gitlinker.hosts".get_gitlab_type_url,
+        ["git.woa.com"] = require"gitlinker.hosts".get_gitwoa_type_url,
         ["try.gitea.io"] = require"gitlinker.hosts".get_gitea_type_url,
         ["codeberg.org"] = require"gitlinker.hosts".get_gitea_type_url,
         ["bitbucket.org"] = require"gitlinker.hosts".get_bitbucket_type_url,

--- a/doc/gitlinker.txt
+++ b/doc/gitlinker.txt
@@ -20,6 +20,7 @@ Supported git web hosts                                   *gitlinker-supported*
 
 * github
 * gitlab
+* git.woa
 * gitea
 * bitbucket
 * gogs
@@ -130,6 +131,7 @@ Here’s all the options with their defaults:
     callbacks = {
           ["github.com"] = require"gitlinker.hosts".get_github_type_url,
           ["gitlab.com"] = require"gitlinker.hosts".get_gitlab_type_url,
+          ["git.woa.com"] = require"gitlinker.hosts".get_gitwoa_type_url,
           ["try.gitea.io"] = require"gitlinker.hosts"get_gitea_type_url,
           ["codeberg.org"] = require"gitlinker.hosts"get_gitea_type_url,
           ["bitbucket.org"] = require"gitlinker.hosts"get_bitbucket_type_url,

--- a/lua/gitlinker/hosts.lua
+++ b/lua/gitlinker/hosts.lua
@@ -26,6 +26,26 @@ function M.get_github_type_url(url_data)
   return url
 end
 
+--- Constructs a git.woa style url
+-- git.woa.com uses a github-style blob path but a gitlab-style line range
+-- (e.g. `#L5-10` instead of github's `#L5-L10`).
+function M.get_gitwoa_type_url(url_data)
+  local url = M.get_base_https_url(url_data)
+  if not url_data.file or not url_data.rev then
+    return url
+  end
+  url = url .. "/blob/" .. url_data.rev .. "/" .. url_data.file
+
+  if not url_data.lstart then
+    return url
+  end
+  url = url .. "#L" .. url_data.lstart
+  if url_data.lend then
+    url = url .. "-" .. url_data.lend
+  end
+  return url
+end
+
 --- Constructs a gitea style url
 function M.get_gitea_type_url(url_data)
   local url = M.get_base_https_url(url_data)
@@ -189,6 +209,7 @@ end
 M.callbacks = {
   ["github.com"] = M.get_github_type_url,
   ["gitlab.com"] = M.get_gitlab_type_url,
+  ["git.woa.com"] = M.get_gitwoa_type_url,
   ["try.gitea.io"] = M.get_gitea_type_url,
   ["codeberg.org"] = M.get_gitea_type_url,
   ["bitbucket.org"] = M.get_bitbucket_type_url,


### PR DESCRIPTION
Add a get_gitwoa_type_url callback that uses github-style blob paths with gitlab-style line ranges (#L5-10 instead of #L5-L10), and register it as the default callback for the git.woa.com host.